### PR TITLE
Add object-assign

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "offline-plugin": "^4.7.0",
     "postcss-salad": "^1.0.8",
     "surge": "^0.19.0",
-    "vbuild": "^7.0.4"
+    "vbuild": "^7.0.6"
   },
   "dependencies": {
     "axios": "^0.16.1",

--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -3,3 +3,5 @@ import Promise from 'promise-polyfill'
 if (!window.Promise) {
   window.Promise = Promise
 }
+
+Object.assign = require('object-assign')

--- a/vbuild.config.js
+++ b/vbuild.config.js
@@ -1,6 +1,6 @@
 const OfflinePlugin = require('offline-plugin')
 
-module.exports = {
+module.exports = options => ({
   postcss: [
     require('postcss-salad')
   ],
@@ -22,4 +22,4 @@ module.exports = {
         }])
     }
   }
-}
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,14 +2,6 @@
 # yarn lockfile v1
 
 
-"@ream/babel-loader@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/@ream/babel-loader/-/babel-loader-7.0.0.tgz#bd6dfb0ede05b3245912d844644088810ce6f9b7"
-  dependencies:
-    find-cache-dir "^0.1.1"
-    loader-utils "^1.0.2"
-    mkdirp "^0.5.1"
-
 abbrev@1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
@@ -387,6 +379,14 @@ babel-load-config@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/babel-load-config/-/babel-load-config-0.1.0.tgz#27280b4a90830c47a1fbbc7baaac4c002cd8c8bd"
 
+babel-loader@7.0.0-beta.1:
+  version "7.0.0-beta.1"
+  resolved "https://registry.npmjs.org/babel-loader/-/babel-loader-7.0.0-beta.1.tgz#1318888dfcbbd5f05750ba2d72c744cc07815ce2"
+  dependencies:
+    find-cache-dir "^0.1.1"
+    loader-utils "^1.0.2"
+    mkdirp "^0.5.1"
+
 babel-messages@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
@@ -681,9 +681,9 @@ babel-preset-env@^1.2.1:
     browserslist "^1.4.0"
     invariant "^2.2.2"
 
-babel-preset-vue-app@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/babel-preset-vue-app/-/babel-preset-vue-app-1.1.1.tgz#2976357df9fa68f1f48e9e315a0d77f29f8f944f"
+babel-preset-vue-app@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/babel-preset-vue-app/-/babel-preset-vue-app-1.2.0.tgz#5ddfb7920020123a2482b12c6b36bdef9e3fb0ad"
   dependencies:
     babel-plugin-syntax-dynamic-import "^6.18.0"
     babel-plugin-transform-object-rest-spread "^6.23.0"
@@ -4962,15 +4962,15 @@ vary@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.1.tgz#67535ebb694c1d52257457984665323f587e8d37"
 
-vbuild@^7.0.4:
-  version "7.0.4"
-  resolved "https://registry.npmjs.org/vbuild/-/vbuild-7.0.4.tgz#0214430dd3df2de388447062b63ceccec4e8fa46"
+vbuild@^7.0.6:
+  version "7.0.6"
+  resolved "https://registry.npmjs.org/vbuild/-/vbuild-7.0.6.tgz#c19198cf759edc4e667a4d13bd8b1193f00817b5"
   dependencies:
-    "@ream/babel-loader" "^7.0.0"
     autoprefixer "^6.7.7"
     babel-core "^6.24.1"
     babel-load-config "^0.1.0"
-    babel-preset-vue-app "^1.1.1"
+    babel-loader "7.0.0-beta.1"
+    babel-preset-vue-app "^1.2.0"
     chalk "^1.1.3"
     clipboardy "^1.1.0"
     co "^4.6.0"


### PR DESCRIPTION
vbuild now disables helpers/polyfills in babel-preset-vue-app, so `Object.assign` won't be polyfilled by default.